### PR TITLE
[PF-1761] Bump bumper GHA to 0.0.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
         ref: ${{ steps.controls.outputs.checkout-branch }}
         token: ${{ secrets.BROADBOT_TOKEN }}
     - name: Bump the tag to a new version
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
       id: tag
       env:
         DEFAULT_BUMP: patch
@@ -83,7 +83,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '290.0.1'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}


### PR DESCRIPTION
Bumber is broken with this error “fatal: unsafe repository ('/github/workspace' is owned by someone else)“

It is related with https://github.com/actions/checkout/issues/760

bumber 0.0.6 fix the issue.